### PR TITLE
change datetime parsing method

### DIFF
--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -1,5 +1,6 @@
 """ Entry point for cli """
 import os
+import re
 import sys
 import argparse
 import warnings
@@ -23,7 +24,8 @@ def parse_args():
         "-s",
         "--start",
         type=str,
-        help="Normal mode: Indicating first date to submit a timesheet. Accepted arguments = ['Day/Month/Year', 'Day/Month/Year', today]. NOTE: 'Month/Day/Year' is not accepted!",
+        help="Normal mode: Indicating first date to submit a timesheet. \
+        		Accepted arguments = ['Day/Month/Year', 'Day/Month/Year', today]. NOTE: 'Month/Day/Year' is not accepted!",
     )
     group.add_argument(
         "-a",
@@ -59,6 +61,29 @@ def parse_args():
     )
     return parser.parse_args()
 
+def get_start_date(start_date_arg):
+	"""parse user's `start` argument"""
+    if start_date_arg.lower() == "today":
+        start_date = datetime.today()
+    else:
+        # PR#22 Parsing Dates with dateutil
+        numbers = re.split("[-/ ]", start_date_arg)
+        # 4 Digit Year
+        if max(map(len, numbers)) == 4:
+            start_date = dateutil.parser.parse(start_date_arg)
+        # 2 Digit Year
+        else:
+            cand1 = dateutil.parser.parse(start_date_arg, dayfirst=True)  # DMY
+            cand2 = dateutil.parser.parse(start_date_arg, yearfirst=True)  # YMD
+            today = datetime.today()
+            diff1 = abs((cand1 - today).total_seconds())
+            diff2 = abs((cand2 - today).total_seconds())
+            # Select Nearest
+            if diff1 < diff2:
+                start_date = cand1
+            else:
+                start_date = cand2
+    return start_date
 
 def run():
     """Entry point"""
@@ -80,27 +105,8 @@ def run():
             "ignore", message="Please take note that, due to arbitrary decisions, "
         )
     cal = Singapore()
-    if args.start.lower() == "today":
-        start_date = datetime.today()
-    else:
-        # PR#22 Parsing Dates with dateutil
-        numbers = re.split("[-/ ]", args.start)
-        # 4 Digit Year
-        if max(map(len, numbers)) == 4:
-            start_date = dateutil.parser.parse(args.start)
-        # 2 Digit Year
-        else:
-            cand1 = dateutil.parser.parse(args.start, dayfirst=True)  # DMY
-            cand2 = dateutil.parser.parse(args.start, yearfirst=True)  # YMD
-            today = datetime.today()
-            diff1 = abs((cand1 - today).total_seconds())
-            diff2 = abs((cand2 - today).total_seconds())
-            # Select Nearest
-            if diff1 < diff2:
-                start_date = cand1
-            else:
-                start_date = cand2
 
+    start_date = get_start_date(args.start)
     dates = date_fn(start=start_date, count=args.count, cal=cal)
     print(f"Date(s) (yyyy-mm-dd) to be submitted for {config.EMAIL}:")
     string_list = [f"{date}: {hours} hours" for (date, hours) in dates]

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -84,17 +84,23 @@ def run():
         start_date = datetime.today()
     else:
         # PR#22 Parsing Dates with dateutil
-        numbers = re.split('[-/ ]', args.start)
+        numbers = re.split("[-/ ]", args.start)
         # 4 Digit Year
         if max(map(len, numbers)) == 4:
             start_date = dateutil.parser.parse(args.start)
-        #2 Digit Year
+        # 2 Digit Year
         else:
-            cand1 = dateutil.parser.parse(args.start, dayfirst=True) #DMY
-            cand2 = dateutil.parser.parse(args.start, yearfirst=True) #YMD
+            cand1 = dateutil.parser.parse(args.start, dayfirst=True)  # DMY
+            cand2 = dateutil.parser.parse(args.start, yearfirst=True)  # YMD
             today = datetime.today()
+            diff1 = abs((cand1 - today).total_seconds())
+            diff2 = abs((cand2 - today).total_seconds())
             # Select Nearest
-            start_date = cand1 if abs((cand1-today).total_seconds()) < abs((cand2-today).total_seconds()) else cand2
+            if diff1 < diff2:
+                start_date = cand1
+            else:
+                start_date = cand2
+
     dates = date_fn(start=start_date, count=args.count, cal=cal)
     print(f"Date(s) (yyyy-mm-dd) to be submitted for {config.EMAIL}:")
     string_list = [f"{date}: {hours} hours" for (date, hours) in dates]

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -3,6 +3,7 @@ import os
 import sys
 import argparse
 import warnings
+import dateutil.parser
 from datetime import datetime
 from workalendar.asia import Singapore
 from tp_timesheet.docker_handler import DockerHandler
@@ -82,7 +83,7 @@ def run():
     if args.start.lower() == "today":
         start_date = datetime.today()
     else:
-        start_date = datetime.strptime(args.start, "%d/%m/%Y")
+        start_date = dateutil.parser.parse(args.start)
     dates = date_fn(start=start_date, count=args.count, cal=cal)
     print(f"Date(s) (yyyy-mm-dd) to be submitted for {config.EMAIL}:")
     string_list = [f"{date}: {hours} hours" for (date, hours) in dates]

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -25,7 +25,8 @@ def parse_args():
         "--start",
         type=str,
         help="Normal mode: Indicating first date to submit a timesheet. \
-                Accepted arguments = ['Day/Month/Year', 'Day/Month/Year', today]. NOTE: 'Month/Day/Year' is not accepted!",
+                Accepted arguments = ['Day/Month/Year', 'Day/Month/Year', today]. \
+                NOTE: 'Month/Day/Year' is not accepted!",
     )
     group.add_argument(
         "-a",

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -83,7 +83,18 @@ def run():
     if args.start.lower() == "today":
         start_date = datetime.today()
     else:
-        start_date = dateutil.parser.parse(args.start)
+        # PR#22 Parsing Dates with dateutil
+        numbers = re.split('[-/ ]', args.start)
+        # 4 Digit Year
+        if max(map(len, numbers)) == 4:
+            start_date = dateutil.parser.parse(args.start)
+        #2 Digit Year
+        else:
+            cand1 = dateutil.parser.parse(args.start, dayfirst=True) #DMY
+            cand2 = dateutil.parser.parse(args.start, yearfirst=True) #YMD
+            today = datetime.today()
+            # Select Nearest
+            start_date = cand1 if abs((cand1-today).total_seconds()) < abs((cand2-today).total_seconds()) else cand2
     dates = date_fn(start=start_date, count=args.count, cal=cal)
     print(f"Date(s) (yyyy-mm-dd) to be submitted for {config.EMAIL}:")
     string_list = [f"{date}: {hours} hours" for (date, hours) in dates]

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -3,8 +3,8 @@ import os
 import sys
 import argparse
 import warnings
-import dateutil.parser
 from datetime import datetime
+import dateutil.parser
 from workalendar.asia import Singapore
 from tp_timesheet.docker_handler import DockerHandler
 from tp_timesheet.submit_form import submit_timesheet

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -23,7 +23,7 @@ def parse_args():
         "-s",
         "--start",
         type=str,
-        help="Normal mode: Indicating first date to submit a timesheet. Accepted arguments = ['dd/mm/yy' ,today]",
+        help="Normal mode: Indicating first date to submit a timesheet. Accepted arguments = ['Day/Month/Year', 'Day/Month/Year', today]. NOTE: 'Month/Day/Year' is not accepted!",
     )
     group.add_argument(
         "-a",

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -25,7 +25,7 @@ def parse_args():
         "--start",
         type=str,
         help="Normal mode: Indicating first date to submit a timesheet. \
-        		Accepted arguments = ['Day/Month/Year', 'Day/Month/Year', today]. NOTE: 'Month/Day/Year' is not accepted!",
+                Accepted arguments = ['Day/Month/Year', 'Day/Month/Year', today]. NOTE: 'Month/Day/Year' is not accepted!",
     )
     group.add_argument(
         "-a",
@@ -62,7 +62,7 @@ def parse_args():
     return parser.parse_args()
 
 def get_start_date(start_date_arg):
-	"""parse user's `start` argument"""
+    """parse user's `start` argument"""
     if start_date_arg.lower() == "today":
         start_date = datetime.today()
     else:

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -61,6 +61,7 @@ def parse_args():
     )
     return parser.parse_args()
 
+
 def get_start_date(start_date_arg):
     """parse user's `start` argument"""
     if start_date_arg.lower() == "today":
@@ -84,6 +85,7 @@ def get_start_date(start_date_arg):
             else:
                 start_date = cand2
     return start_date
+
 
 def run():
     """Entry point"""


### PR DESCRIPTION
related issue : #19

replaced datetime parsing method to standard module named `dateutil.parser`.

tested(succeeded)
- Hyphens
    - '30-Nov-2022'
    - 'Nov-30-2022'
    - '30-8-22'
    - '30-Nov-22'
    - '30-November-22'
- No space
    - '30Nov2022'
- Space
    - '30 November 2022'
    - 'Nov 30 2022'
    - '30 Nov 2022'
    - '30 08 22'
    - '30 8 22'
- Slash
    - '30/08/22'
    - '30/Nov/22'
    - '30/November/22'
- Mixed
    - '30November 2022'
    - '30Nov       22'
    - 30/November 22'
