### PR TITLE
cicd: clear config and logs before each build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
         stage('Python Environment') {
             steps {
                 sh '''
+                rm -vr ~/.config/tp-timesheet || true
                 virtualenv venv -p python3.9
                 . venv/bin/activate
                 pip install --upgrade pip


### PR DESCRIPTION
Makes sure configs and logs are cleared before each new commit is checked. Should help avoid build issues if changes are made to the config or logs