### PR TITLE
Migrate to docker builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent { label 'docker && linux' }
     options {
-        timeout(time: 15, unit: 'MINUTES')
+        timeout(time: 30, unit: 'MINUTES')
     }
     environment {
         DOCKER_IMAGE = 'python'
@@ -23,6 +23,9 @@ pipeline {
                 }
                 stages {
                     stage('Python Environment') {
+                        options {
+                            timeout(time: 5, unit: 'MINUTES')
+                        }
                         steps {
                             echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
@@ -34,6 +37,9 @@ pipeline {
                         }
                     }
                     stage('Code Format') {
+                        options {
+                            timeout(time: 30, unit: 'SECONDS')
+                        }
                         steps {
                             echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
@@ -43,6 +49,9 @@ pipeline {
                         }
                     }
                     stage('Linter') {
+                        options {
+                            timeout(time: 1, unit: 'MINUTES')
+                        }
                         steps {
                             echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
@@ -52,6 +61,9 @@ pipeline {
                         }
                     }
                     stage('Unit Tests') {
+                        options {
+                            timeout(time: 1, unit: 'MINUTES')
+                        }
                         steps {
                             echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,22 @@
 pipeline {
     options {
-        timeout(time: 10, unit: 'MINUTES')
+        timeout(time: 5, unit: 'MINUTES')
+    }
+    agent {
+        docker {
+            image 'python:3.8-slim'
+	    args '-e "HOME=$WORKSPACE"'
         }
-    agent any
+    }
     stages {
         stage('Python Environment') {
             steps {
                 sh '''
-                rm -vr ~/.config/tp-timesheet || true
-                virtualenv venv -p python3.9
-                . venv/bin/activate
+                echo "HOME: $HOME"
+                echo "~/"
+		pwd
+                python -m venv venv
+		. venv/bin/activate
                 pip install --upgrade pip
                 pip install .[dev]
                 '''
@@ -18,7 +25,7 @@ pipeline {
         stage('Code Formatter') {
             steps {
                 sh '''
-                . venv/bin/activate
+		. venv/bin/activate
                 black --check --diff tp_timesheet
                 '''
             }
@@ -26,7 +33,7 @@ pipeline {
         stage('Linter') {
             steps {
                 sh '''
-                . venv/bin/activate
+		. venv/bin/activate
                 pylint tp_timesheet
                 '''
             }
@@ -34,8 +41,8 @@ pipeline {
         stage('Unit Tests') {
             steps {
                 sh '''
-                . venv/bin/activate
-                tox
+		. venv/bin/activate
+                pytest
                 '''
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent { label 'docker && linux' }
     options {
-        timeout(time: 5, unit: 'MINUTES')
+        timeout(time: 15, unit: 'MINUTES')
     }
     environment {
         DOCKER_IMAGE = 'python'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,49 +1,59 @@
 pipeline {
+    agent { label 'docker && linux' }
     options {
         timeout(time: 5, unit: 'MINUTES')
     }
-    agent {
-        docker {
-            image 'python:3.8-slim'
-	    args '-e "HOME=$WORKSPACE"'
-        }
-    }
     stages {
-        stage('Python Environment') {
-            steps {
-                sh '''
-                echo "HOME: $HOME"
-                echo "~/"
-		pwd
-                python -m venv venv
-		. venv/bin/activate
-                pip install --upgrade pip
-                pip install .[dev]
-                '''
-            }
-        }
-        stage('Code Formatter') {
-            steps {
-                sh '''
-		. venv/bin/activate
-                black --check --diff tp_timesheet
-                '''
-            }
-        }
-        stage('Linter') {
-            steps {
-                sh '''
-		. venv/bin/activate
-                pylint tp_timesheet
-                '''
-            }
-        }
-        stage('Unit Tests') {
-            steps {
-                sh '''
-		. venv/bin/activate
-                pytest
-                '''
+        stage('Build And Test Pipeline') {
+            matrix {
+                agent {
+                    docker {
+                        image "python:${DOCKER_TAG}"
+                        args '-e "HOME=$WORKSPACE"'
+                    }
+                }
+                axes {
+                    axis {
+                        name 'DOCKER_TAG'
+                        values '3.7-slim', '3.8-slim', '3.9-slim', '3.10-slim', '3.11-rc-slim'
+                    }
+                }
+                stages {
+                    stage('Python Environment') {
+                        steps {
+                            sh '''
+                            python -m venv venv
+                            . venv/bin/activate
+                            pip install --upgrade pip
+                            pip install .[dev]
+                            '''
+                        }
+                    }
+                    stage('Code Format') {
+                        steps {
+                            sh '''
+                            . venv/bin/activate
+                            black --check --diff tp_timesheet
+                            '''
+                        }
+                    }
+                    stage('Linter') {
+                        steps {
+                            sh '''
+                            . venv/bin/activate
+                            pylint tp_timesheet
+                            '''
+                        }
+                    }
+                    stage('Unit Tests') {
+                        steps {
+                            sh '''
+                            . venv/bin/activate
+                            pytest
+                            '''
+                        }
+                    }
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,15 @@ pipeline {
     options {
         timeout(time: 5, unit: 'MINUTES')
     }
+    environment {
+        DOCKER_IMAGE = 'python'
+    }
     stages {
         stage('Build And Test Pipeline') {
             matrix {
                 agent {
                     docker {
-                        image "python:${DOCKER_TAG}"
+                        image "${DOCKER_IMAGE}:${DOCKER_TAG}"
                         args '-e "HOME=$WORKSPACE"'
                     }
                 }
@@ -21,6 +24,7 @@ pipeline {
                 stages {
                     stage('Python Environment') {
                         steps {
+                            echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
                             python -m venv venv
                             . venv/bin/activate
@@ -31,6 +35,7 @@ pipeline {
                     }
                     stage('Code Format') {
                         steps {
+                            echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
                             . venv/bin/activate
                             black --check --diff tp_timesheet
@@ -39,6 +44,7 @@ pipeline {
                     }
                     stage('Linter') {
                         steps {
+                            echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
                             . venv/bin/activate
                             pylint tp_timesheet
@@ -47,6 +53,7 @@ pipeline {
                     }
                     stage('Unit Tests') {
                         steps {
+                            echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
                             . venv/bin/activate
                             pytest

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ DEV_REQUIREMENTS = {
         "pytest>=6.0.0",
         "pylint~=2.13",
         "black>=22.8",
-        "tox>= 3.0.0",
     ]
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py38, py39
-
-[testenv]
-deps = .[dev]
-commands = pytest


### PR DESCRIPTION
Currently Jenkins runs the builds across multiple versions of python, each in their own virtual environment. This requires multiple version of python interpreter to be built from source (takes a few hours) and installed each time Jenkins is updated.

The proposed changes remove the need for this and be able to support more flexible Jenkins pipeline environments by moving to docker pipelines.

This repo will run each stage of its checks within an isolated docker container, based on the official python images from dockerhub. This means we can run the pipeline on new versions of python as they come out just by adding it to the matrix list.

[DockerHub Python Images](https://hub.docker.com/_/python)
Line 18 Selects what Python images to run pipeline on:
`values '3.7-slim', '3.8-slim', '3.9-slim', '3.10-slim', '3.11-rc-slim'`

If you check the Jenkins build page, you will see the matrix of pipelines for each python version in the list above.