### PR TITLE
feat: pop up dialog if code runs into exception

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -450,7 +450,7 @@ max-attributes=7
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=15
+max-branches=25
 
 # Maximum number of locals for function / method body.
 max-locals=20
@@ -465,7 +465,7 @@ max-public-methods=20
 max-returns=6
 
 # Maximum number of statements in function / method body.
-max-statements=50
+max-statements=70
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -6,6 +6,7 @@ import argparse
 import warnings
 import selenium
 import regex as re
+import docker
 from workalendar.asia import Singapore
 from tp_timesheet.docker_handler import DockerHandler
 from tp_timesheet.submit_form import submit_timesheet
@@ -116,13 +117,13 @@ def run():
 
     try:
         docker_handler = DockerHandler()
-    except Exception as e:  # to catch when Docker fails
-        if re.search(".*\n", str(e)):
-            message = re.search(".*\n", str(e))
-            print(message[0])
+    except docker.errors.DockerException as d_exception:
+        if re.search(".*\n", str(d_exception)):
+            message = re.search(".*\n", str(d_exception))
+            logger.error(message[0])
         else:
-            message = e
-            print(message)
+            message = d_exception
+            logger.error(message)
         notification_text = (
             "⚠️ TP-timesheet submitted not successfully. Check if Docker is running"
         )
@@ -156,27 +157,27 @@ def run():
                 notification_text = f"Timesheets from {dates[0]} to {dates[-1]} are successfully submitted."
             if args.dry_run:
                 notification_text = f"[DRY_RUN] {notification_text}"
-        os.system(
-            f"""osascript -e 'display notification "{notification_text}" with title "TP Timesheet"'"""
-        )
-    except selenium.common.exceptions.NoSuchElementException as e:
-        if re.search(".*\n", str(e)):
-            message = re.search(".*\n", str(e))
-            print(message[0])
+            os.system(
+                f"""osascript -e 'display notification "{notification_text}" with title "TP Timesheet"'"""
+            )
+    except selenium.common.exceptions.NoSuchElementException as s_exception:
+        if re.search(".*\n", str(s_exception)):
+            message = re.search(".*\n", str(s_exception))
+            logger.error(message[0])
         else:
-            message = e
-            print(message)
+            message = s_exception
+            logger.error(message)
         notification_text = "⚠️ TP Timesheet was not submitted successfully. An element on the url was not found by Selenium"
         os.system(
             f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" default button "OK" with icon 2'"""
         )
-    except Exception as e:
-        if re.search(".*\n", str(e)):
-            message = re.search(".*\n", str(e))
-            print(message[0])
+    except Exception as gen_exception:
+        if re.search(".*\n", str(gen_exception)):
+            message = re.search(".*\n", str(gen_exception))
+            logger.error(message[0])
         else:
-            message = e
-            print(message)
+            message = gen_exception
+            logger.error(message)
         notification_text = "⚠️ TP Timesheet was not submitted successfully."
         os.system(
             f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" default button "OK" with icon 2'"""

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -170,13 +170,14 @@ def run():
 was not found by Selenium"
             raise TpException(notification_text) from s_exception
     except Exception as gen_exception:
-        logger.error(gen_exception, exc_info=True)
+        logger.critical(gen_exception, exc_info=True)
         if not notification_text:
             notification_text = "⚠️ TP Timesheet was not submitted successfully."
         os.system(
             f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" \
                     default button "OK" with icon 2'"""
         )
+        sys.exit(1)
     finally:
         try:
             logger.debug("Cleaning up docker container")

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -5,7 +5,6 @@ import sys
 import argparse
 import warnings
 import selenium
-import regex as re
 import docker
 from workalendar.asia import Singapore
 from tp_timesheet.docker_handler import DockerHandler
@@ -118,17 +117,14 @@ def run():
     try:
         docker_handler = DockerHandler()
     except docker.errors.DockerException as d_exception:
-        if re.search(".*\n", str(d_exception)):
-            message = re.search(".*\n", str(d_exception))
-            logger.error(message[0])
-        else:
-            message = d_exception
-            logger.error(message)
+        message = d_exception
+        logger.exception(message)
         notification_text = (
             "⚠️ TP-timesheet submitted not successfully. Check if Docker is running"
         )
         os.system(
-            f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" default button "OK" with icon 2'"""
+            f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" \
+            		default button "OK" with icon 2'"""
         )
         return
     try:
@@ -161,26 +157,19 @@ def run():
                 f"""osascript -e 'display notification "{notification_text}" with title "TP Timesheet"'"""
             )
     except selenium.common.exceptions.NoSuchElementException as s_exception:
-        if re.search(".*\n", str(s_exception)):
-            message = re.search(".*\n", str(s_exception))
-            logger.error(message[0])
-        else:
-            message = s_exception
-            logger.error(message)
-        notification_text = "⚠️ TP Timesheet was not submitted successfully. An element on the url was not found by Selenium"
+        logger.error(s_exception)
+        notification_text = "⚠️ TP Timesheet was not submitted successfully. An element on the url was not \
+        		found by Selenium"
         os.system(
-            f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" default button "OK" with icon 2'"""
+            f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" \
+            		default button "OK" with icon 2'"""
         )
     except Exception as gen_exception:
-        if re.search(".*\n", str(gen_exception)):
-            message = re.search(".*\n", str(gen_exception))
-            logger.error(message[0])
-        else:
-            message = gen_exception
-            logger.error(message)
+        logger.error(gen_exception)
         notification_text = "⚠️ TP Timesheet was not submitted successfully."
         os.system(
-            f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" default button "OK" with icon 2'"""
+            f"""osascript -e 'display dialog "{notification_text}" with title "TP Timesheet" buttons "OK" \
+            		default button "OK" with icon 2'"""
         )
 
     finally:

--- a/tp_timesheet/submit_form.py
+++ b/tp_timesheet/submit_form.py
@@ -33,17 +33,11 @@ def submit_timesheet(url, email, date, verbose=False, dry_run=False, working_hou
         browser.implicitly_wait(5)
 
         # find the email field element and fill your email
-        email_field = browser.find_element(
-            By.XPATH,
-            "(//input)[1]",
-        )
+        email_field = browser.find_element(By.XPATH, "(//input)[1]",)
         email_field.send_keys(email)
 
         # find the date field and fill date
-        date_field = browser.find_element(
-            By.XPATH,
-            "(//input)[2]",
-        )
+        date_field = browser.find_element(By.XPATH, "(//input)[2]",)
         date_field.send_keys(date.strftime("%m/%d/%Y"))
 
         if verbose:
@@ -57,35 +51,20 @@ def submit_timesheet(url, email, date, verbose=False, dry_run=False, working_hou
             image.show()
 
         # find and fill in live hours
-        live_hours = browser.find_element(
-            By.XPATH,
-            "(//input)[3]",
-        )
+        live_hours = browser.find_element(By.XPATH, "(//input)[3]",)
         live_hours.send_keys(working_hours)
 
         # find and fill in the rest of the hours
-        idle_hours = browser.find_element(
-            By.XPATH,
-            "(//input)[4]",
-        )
+        idle_hours = browser.find_element(By.XPATH, "(//input)[4]",)
         idle_hours.send_keys("0")
-        training_hours = browser.find_element(
-            By.XPATH,
-            "(//input)[5]",
-        )
+        training_hours = browser.find_element(By.XPATH, "(//input)[5]",)
         training_hours.send_keys("0")
-        tool_issues = browser.find_element(
-            By.XPATH,
-            "(//input)[6]",
-        )
+        tool_issues = browser.find_element(By.XPATH, "(//input)[6]",)
         tool_issues.send_keys("0")
 
         if not dry_run:
             # find submit button and click submit
-            submit = browser.find_element(
-                By.XPATH,
-                "(//button)[2]/div[1]",
-            )
+            submit = browser.find_element(By.XPATH, "(//button)[2]/div[1]",)
             submit.click()
         browser.implicitly_wait(5)
 

--- a/tp_timesheet/submit_form.py
+++ b/tp_timesheet/submit_form.py
@@ -33,11 +33,17 @@ def submit_timesheet(url, email, date, verbose=False, dry_run=False, working_hou
         browser.implicitly_wait(5)
 
         # find the email field element and fill your email
-        email_field = browser.find_element(By.XPATH, "(//input)[1]",)
+        email_field = browser.find_element(
+            By.XPATH,
+            "(//input)[1]",
+        )
         email_field.send_keys(email)
 
         # find the date field and fill date
-        date_field = browser.find_element(By.XPATH, "(//input)[2]",)
+        date_field = browser.find_element(
+            By.XPATH,
+            "(//input)[2]",
+        )
         date_field.send_keys(date.strftime("%m/%d/%Y"))
 
         if verbose:
@@ -51,20 +57,35 @@ def submit_timesheet(url, email, date, verbose=False, dry_run=False, working_hou
             image.show()
 
         # find and fill in live hours
-        live_hours = browser.find_element(By.XPATH, "(//input)[3]",)
+        live_hours = browser.find_element(
+            By.XPATH,
+            "(//input)[3]",
+        )
         live_hours.send_keys(working_hours)
 
         # find and fill in the rest of the hours
-        idle_hours = browser.find_element(By.XPATH, "(//input)[4]",)
+        idle_hours = browser.find_element(
+            By.XPATH,
+            "(//input)[4]",
+        )
         idle_hours.send_keys("0")
-        training_hours = browser.find_element(By.XPATH, "(//input)[5]",)
+        training_hours = browser.find_element(
+            By.XPATH,
+            "(//input)[5]",
+        )
         training_hours.send_keys("0")
-        tool_issues = browser.find_element(By.XPATH, "(//input)[6]",)
+        tool_issues = browser.find_element(
+            By.XPATH,
+            "(//input)[6]",
+        )
         tool_issues.send_keys("0")
 
         if not dry_run:
             # find submit button and click submit
-            submit = browser.find_element(By.XPATH, "(//button)[2]/div[1]",)
+            submit = browser.find_element(
+                By.XPATH,
+                "(//button)[2]/div[1]",
+            )
             submit.click()
         browser.implicitly_wait(5)
 


### PR DESCRIPTION
This is a draft for addressing part of issue #49. The code is not concise and these are the things raised by pylint:
`************* Module tp_timesheet.__main__
tp_timesheet/__main__.py:120:0: C0301: Line too long (141/120) (line-too-long)
tp_timesheet/__main__.py:159:0: C0301: Line too long (125/120) (line-too-long)
tp_timesheet/__main__.py:161:0: C0301: Line too long (141/120) (line-too-long)
tp_timesheet/__main__.py:172:0: C0301: Line too long (141/120) (line-too-long)
tp_timesheet/__main__.py:163:11: W0703: Catching too general exception Exception (broad-except)
tp_timesheet/__main__.py:69:0: R0912: Too many branches (21/15) (too-many-branches)
tp_timesheet/__main__.py:69:0: R0915: Too many statements (67/50) (too-many-statements)`

Any suggestions on how to make the exceptions look better? Currently, there is one for when docker fails, one for when selenium fails and one for the general failing. And the `os.system( f"""...` is repeated many times . The message to be logged into the logger is also printed out for now.