### PR TITLE
cicd: drop support for python<=3.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                 axes {
                     axis {
                         name 'DOCKER_TAG'
-                        values '3.7-slim', '3.8-slim', '3.9-slim', '3.10-slim', '3.11-slim'
+                        values '3.8-slim', '3.9-slim', '3.10-slim', '3.11-slim'
                     }
                 }
                 stages {

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     extras_require=DEV_REQUIREMENTS,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",


### PR DESCRIPTION
Benefits:
- Reduce maintenance burden 
- Reduce pipeline loads
- Python 3.7 is EOL