### PR TITLE
fix: config update bug

### DIFF
--- a/tp_timesheet/config.py
+++ b/tp_timesheet/config.py
@@ -122,7 +122,8 @@ class Config:
             config["configuration"] = {
                 "tp_email": email,
                 "tp_url": url,
-            }.update(cls.DEFAULT_CONF)
+            }
+            config["configuration"].update(cls.DEFAULT_CONF)
 
             with open(cls.CONFIG_PATH, "w", encoding="utf8") as config_file:
                 config.write(config_file)


### PR DESCRIPTION
Calling `a.update(b)` merges `b` into `a` inplace, and returns `None` which was causing the error.