### PR TITLE
Add locale tags to submission

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -444,7 +444,7 @@ ignored-parents=
 max-args=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -95,7 +95,9 @@ def run():
 
     try:
         DockerHandler.install_and_launch_docker()
-        clockify = Clockify(config.CLOCKIFY_API_KEY, task=args.task)
+        clockify = Clockify(
+            config.CLOCKIFY_API_KEY, task=args.task, locale=config.LOCALE
+        )
 
         # Automate Mode
         if args.automate is not None:

--- a/tp_timesheet/__main__.py
+++ b/tp_timesheet/__main__.py
@@ -78,7 +78,7 @@ def parse_args():
         type=str,
         default="live",
         help="The type of task for the clockify submission. Specify task name "
-        + "if it anything other than 'live'. Put the task name (training, OOO, holiday) in small letters",
+        + "if it is anything other than 'live'. Put the task name (training, OOO, holiday) in small letters",
     )
     return parser.parse_args()
 

--- a/tp_timesheet/clockify_timesheet.py
+++ b/tp_timesheet/clockify_timesheet.py
@@ -175,7 +175,7 @@ class Clockify:
             if dic["name"] == project:
                 return dic["id"]
         raise ValueError(
-            f'Could not find project named "{project}", check your API key'
+            f'Could not find project named "{project}", check your project name'
         )
 
     def _get_task_id(self, task_short):
@@ -191,7 +191,7 @@ class Clockify:
         for dic in request_list:
             if dic["name"] == task:
                 return dic["id"]
-        raise ValueError(f'Could not find task named "{task}", check your API key')
+        raise ValueError(f'Could not find task named "{task}", check your task name')
 
     def _get_locale_id(self, locale):
         get_request = requests.get(
@@ -204,4 +204,6 @@ class Clockify:
         for dic in request_list:
             if dic["name"] == locale:
                 return dic["id"]
-        raise ValueError(f'Could not find locale named "{locale}", check your API key')
+        raise ValueError(
+            f'Could not find locale named "{locale}", check your locale tag'
+        )

--- a/tp_timesheet/clockify_timesheet.py
+++ b/tp_timesheet/clockify_timesheet.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 class Clockify:
     """Clockify class, contains all methods required to set up and submit entry to clockify"""
 
+    # pylint: disable=too-many-instance-attributes
     task_project_dict = {
         "live": ("Live hours", "Jupiter Staffing APAC"),
         "training": ("Training", "Jupiter Staffing APAC"),
@@ -20,8 +21,15 @@ class Clockify:
     }
 
     api_base_endpoint = "https://api.clockify.me/api/v1"
+    tag_dict = {
+        "en_AU": "63519fce3da4c53079d15ebc",
+        "en_SG": "63519fde28051215c2de5647",
+        "ko_KR": "63519ff23da4c53079d1609c",
+        "ms_MY": "6280f9aaa54b17079938f87b",
+        "th_TH": "6280f9c9a54b17079938f8cf",
+    }
 
-    def __init__(self, api_key, task):
+    def __init__(self, api_key, task, locale):
         self.api_key = api_key
 
         (
@@ -32,6 +40,7 @@ class Clockify:
         ) = self._get_workspace_user_id()
         self.project_id = self._get_project_id(task)
         self.task_id = self._get_task_id(task)
+        self.locale_id = self.tag_dict[locale]
 
     def submit_clockify(self, date, working_hours, dry_run=False):
         """Submit entry to clockify"""
@@ -65,6 +74,7 @@ class Clockify:
             "billable": True,
             "projectId": self.project_id,
             "taskId": self.task_id,
+            "tagIds": [self.locale_id],
         }
 
         if dry_run:

--- a/tp_timesheet/clockify_timesheet.py
+++ b/tp_timesheet/clockify_timesheet.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 class Clockify:
     """Clockify class, contains all methods required to set up and submit entry to clockify"""
 
-    # pylint: disable=too-many-instance-attributes
     task_project_dict = {
         "live": ("Live hours", "Jupiter Staffing APAC"),
         "training": ("Training", "Jupiter Staffing APAC"),
@@ -21,13 +20,6 @@ class Clockify:
     }
 
     api_base_endpoint = "https://api.clockify.me/api/v1"
-    tag_dict = {
-        "en_AU": "63519fce3da4c53079d15ebc",
-        "en_SG": "63519fde28051215c2de5647",
-        "ko_KR": "63519ff23da4c53079d1609c",
-        "ms_MY": "6280f9aaa54b17079938f87b",
-        "th_TH": "6280f9c9a54b17079938f8cf",
-    }
 
     def __init__(self, api_key, task, locale):
         self.api_key = api_key
@@ -40,7 +32,7 @@ class Clockify:
         ) = self._get_workspace_user_id()
         self.project_id = self._get_project_id(task)
         self.task_id = self._get_task_id(task)
-        self.locale_id = self.tag_dict[locale]
+        self.locale_id = self._get_locale_id(locale)
 
     def submit_clockify(self, date, working_hours, dry_run=False):
         """Submit entry to clockify"""
@@ -200,3 +192,16 @@ class Clockify:
             if dic["name"] == task:
                 return dic["id"]
         raise ValueError(f'Could not find task named "{task}", check your API key')
+
+    def _get_locale_id(self, locale):
+        get_request = requests.get(
+            f"{self.api_base_endpoint}/workspaces/{self.workspace_id}/tags",
+            headers={"X-Api-Key": self.api_key},
+            timeout=2,
+        )
+        get_request.raise_for_status()
+        request_list = json.loads(get_request.text)
+        for dic in request_list:
+            if dic["name"] == locale:
+                return dic["id"]
+        raise ValueError(f'Could not find locale named "{locale}", check your API key')

--- a/tp_timesheet/config.py
+++ b/tp_timesheet/config.py
@@ -28,10 +28,12 @@ class Config:
     clockify_api_key = {
         "clockify_api_key": "AbCD1234AbCD1234AbCD1234AbCD1234AbCD1234AbCD1234"
     }
+    locale_tag = {"locale_tag": "xx_XX"}
     DEFAULT_CONF = {
         **sanity_check_bool_dict,
         **sanity_check_range_dict,
         **clockify_api_key,
+        **locale_tag,
     }
 
     @classmethod
@@ -135,13 +137,9 @@ class Config:
             url = input("Enter timesheet url:")
             while not cls.is_valid_url(url):
                 url = input("Invalid url, please try again:")
-            locale = input("Enter locale:")
-            while not cls.is_valid_locale(locale):
-                locale = input("Invalid locale, please try again:")
             config["configuration"] = {
                 "tp_email": email,
                 "tp_url": url,
-                "locale_tag": locale,
             }
             config["configuration"].update(cls.DEFAULT_CONF)
 
@@ -172,6 +170,14 @@ class Config:
             input_config.set(
                 "configuration", next(iter(cls.clockify_api_key)), clockify_api
             )
+        if (
+            input_config.get("configuration", next(iter(cls.locale_tag)))
+            == cls.locale_tag[next(iter(cls.locale_tag))]
+        ):
+            locale_tag = input("Enter locale tag:")
+            while not cls.is_valid_locale(locale_tag):
+                locale_tag = input("Invalid locale, please try again:")
+            input_config.set("configuration", next(iter(cls.locale_tag)), locale_tag)
 
         with open(cls.CONFIG_PATH, "w", encoding="utf8") as config_file:
             input_config.write(config_file)

--- a/tp_timesheet/config.py
+++ b/tp_timesheet/config.py
@@ -37,7 +37,7 @@ class Config:
     @classmethod
     def __init__(cls, verbose=False, config_filename="tp.conf"):
         """This is the entry point for the class and running this will setup the tp-timesheet
-        config and make all the necesarry globals available
+        config and make all the necessary globals available
         """
         cls.VERBOSE = verbose
         cls.CONFIG_DIR = Config.CONFIG_DIR
@@ -52,6 +52,7 @@ class Config:
         # Load global configurations
         cls.EMAIL = config.get("configuration", "tp_email")
         cls.URL = config.get("configuration", "tp_url")
+        cls.LOCALE = config.get("configuration", "locale_tag")
         cls.SANITY_CHECK_START_DATE = config.get(
             "configuration", next(iter(cls.sanity_check_bool_dict))
         )
@@ -112,6 +113,12 @@ class Config:
         len_api = len(api_key) > 40
         return regex_api & len_api
 
+    @staticmethod
+    def is_valid_locale(locale):
+        """Check locale is valid"""
+        regex = re.match("^[a-z]{2}_[A-Z]{2}$", locale)
+        return bool(regex)
+
     @classmethod
     def _read_write_config(cls):
         """Function to read the config file or create one if it doesn't exist"""
@@ -128,9 +135,13 @@ class Config:
             url = input("Enter timesheet url:")
             while not cls.is_valid_url(url):
                 url = input("Invalid url, please try again:")
+            locale = input("Enter locale:")
+            while not cls.is_valid_locale(locale):
+                locale = input("Invalid locale, please try again:")
             config["configuration"] = {
                 "tp_email": email,
                 "tp_url": url,
+                "locale_tag": locale,
             }
             config["configuration"].update(cls.DEFAULT_CONF)
 

--- a/tp_timesheet/config.py
+++ b/tp_timesheet/config.py
@@ -29,7 +29,7 @@ class Config:
         "clockify_api_key": "AbCD1234AbCD1234AbCD1234AbCD1234AbCD1234AbCD1234"
     }
     locale_list = ["en_AU", "en_SG", "ko_KR", "ms_MY", "th_TH"]
-    locale_tag = {"locale_tag": "en_AU"}
+    locale_tag = {"locale_tag": "xx_XX"}
     DEFAULT_CONF = {
         **sanity_check_bool_dict,
         **sanity_check_range_dict,
@@ -116,7 +116,6 @@ class Config:
         len_api = len(api_key) > 40
         return regex_api & len_api
 
-    # pylint:disable = too-many-function-args
     @classmethod
     def is_valid_locale(cls, locale):
         """Check locale is valid"""

--- a/tp_timesheet/config.py
+++ b/tp_timesheet/config.py
@@ -7,6 +7,7 @@ import os
 import re
 import configparser
 from pathlib import Path
+from tp_timesheet.clockify_timesheet import Clockify
 
 logger = logging.getLogger(__name__)
 
@@ -175,8 +176,9 @@ class Config:
             == cls.locale_tag[next(iter(cls.locale_tag))]
         ):
             locale_tag = input("Enter locale tag:")
+            poss_locales = list(Clockify.tag_dict.keys())
             while not cls.is_valid_locale(locale_tag):
-                locale_tag = input("Invalid locale, please try again:")
+                locale_tag = input(f"Please choose from {poss_locales}, try again:")
             input_config.set("configuration", next(iter(cls.locale_tag)), locale_tag)
 
         with open(cls.CONFIG_PATH, "w", encoding="utf8") as config_file:

--- a/tp_timesheet/config.py
+++ b/tp_timesheet/config.py
@@ -7,7 +7,6 @@ import os
 import re
 import configparser
 from pathlib import Path
-from tp_timesheet.clockify_timesheet import Clockify
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,8 @@ class Config:
     clockify_api_key = {
         "clockify_api_key": "AbCD1234AbCD1234AbCD1234AbCD1234AbCD1234AbCD1234"
     }
-    locale_tag = {"locale_tag": "xx_XX"}
+    locale_list = ["en_AU", "en_SG", "ko_KR", "ms_MY", "th_TH"]
+    locale_tag = {"locale_tag": "en_AU"}
     DEFAULT_CONF = {
         **sanity_check_bool_dict,
         **sanity_check_range_dict,
@@ -116,11 +116,12 @@ class Config:
         len_api = len(api_key) > 40
         return regex_api & len_api
 
-    @staticmethod
-    def is_valid_locale(locale):
+    # pylint:disable = too-many-function-args
+    @classmethod
+    def is_valid_locale(cls, locale):
         """Check locale is valid"""
-        regex = re.match("^[a-z]{2}_[A-Z]{2}$", locale)
-        return bool(regex)
+        valid = locale in cls.locale_list
+        return valid
 
     @classmethod
     def _read_write_config(cls):
@@ -175,8 +176,8 @@ class Config:
             input_config.get("configuration", next(iter(cls.locale_tag)))
             == cls.locale_tag[next(iter(cls.locale_tag))]
         ):
-            locale_tag = input("Enter locale tag:")
-            poss_locales = list(Clockify.tag_dict.keys())
+            poss_locales = cls.locale_list
+            locale_tag = input(f"Enter locale tag ({poss_locales}):")
             while not cls.is_valid_locale(locale_tag):
                 locale_tag = input(f"Please choose from {poss_locales}, try again:")
             input_config.set("configuration", next(iter(cls.locale_tag)), locale_tag)

--- a/tp_timesheet/tests/test_clockify_ids.py
+++ b/tp_timesheet/tests/test_clockify_ids.py
@@ -29,7 +29,7 @@ def test_ids(clockify_config):
     tasks = ["live", "training", "OOO", "holiday"]
     for selected_t in tasks:
         clockify_val = Clockify(
-            api_key=config.CLOCKIFY_API_KEY, task=selected_t, locale="en_SG"
+            api_key=config.CLOCKIFY_API_KEY, task=selected_t, locale=config.LOCALE
         )
         assert (
             clockify_val.workspace_id == WORKSPACE_ID

--- a/tp_timesheet/tests/test_clockify_ids.py
+++ b/tp_timesheet/tests/test_clockify_ids.py
@@ -28,7 +28,9 @@ def test_ids(clockify_config):
     config = Config(config_filename=clockify_config)
     tasks = ["live", "training", "OOO", "holiday"]
     for selected_t in tasks:
-        clockify_val = Clockify(api_key=config.CLOCKIFY_API_KEY, task=selected_t)
+        clockify_val = Clockify(
+            api_key=config.CLOCKIFY_API_KEY, task=selected_t, locale="en_SG"
+        )
         assert (
             clockify_val.workspace_id == WORKSPACE_ID
         ), f"Workspace ID Error, expected: {WORKSPACE_ID}, result:{clockify_val.workspace_id}"

--- a/tp_timesheet/tests/test_clockify_ids.py
+++ b/tp_timesheet/tests/test_clockify_ids.py
@@ -61,7 +61,9 @@ def test_remove_existing_entries(clockify_config):
 
     # Instantiate a Clockify object
     config = Config(config_filename=clockify_config)
-    clockify = Clockify(api_key=config.CLOCKIFY_API_KEY, task="training")
+    clockify = Clockify(
+        api_key=config.CLOCKIFY_API_KEY, task="training", locale=config.LOCALE
+    )
 
     # Use following date as test date. Random future date in January
     test_date = datetime.date(

--- a/tp_timesheet/tests/test_config.py
+++ b/tp_timesheet/tests/test_config.py
@@ -115,6 +115,8 @@ def test_config_upgrade_process(tmp_v3_config):
         new_parameters["clockify_api_key"],
         new_parameters["locale_tag"],
     ]
+    # Inject fake locale into list for test so is_valid_locale can pass
+    Config.locale_list.append(new_parameters["locale_tag"])
     with mock.patch.object(builtins, "input", lambda _: mock_inputs()):
         Config(config_filename=tmp_v3_config)
 

--- a/tp_timesheet/tests/test_config.py
+++ b/tp_timesheet/tests/test_config.py
@@ -50,6 +50,7 @@ def fixture_create_tmp_clockify_api_config():
 tp_email = fake@email.com
 tp_url = https://example.com/path
 clockify_api_key = {api_key}
+locale = en_SG
     """
     with open(test_config_path, "w", encoding="utf8") as conf_file:
         conf_file.write(config_str)

--- a/tp_timesheet/tests/test_config.py
+++ b/tp_timesheet/tests/test_config.py
@@ -25,6 +25,7 @@ def fixture_create_tmp_mock_config():
 tp_email = fake@email.com
 tp_url = https://example.com/path
 clockify_api_key = some_random_api
+locale_tag = ab_CD
     """
     with open(test_config_path, "w", encoding="utf8") as conf_file:
         conf_file.write(config_str)
@@ -50,7 +51,7 @@ def fixture_create_tmp_clockify_api_config():
 tp_email = fake@email.com
 tp_url = https://example.com/path
 clockify_api_key = {api_key}
-locale = en_SG
+locale_tag = en_SG
     """
     with open(test_config_path, "w", encoding="utf8") as conf_file:
         conf_file.write(config_str)
@@ -108,9 +109,13 @@ def test_config_upgrade_process(tmp_v3_config):
     assert list(config_dict["configuration"]) == ["tp_email", "tp_url"]
 
     # Initialize config which performs the upgrade
-    with mock.patch.object(
-        builtins, "input", lambda _: new_parameters["clockify_api_key"]
-    ):
+    # Create an iterable side_effect such that mock_inputs returns the next value each time it is called
+    mock_inputs = mock.Mock()
+    mock_inputs.side_effect = [
+        new_parameters["clockify_api_key"],
+        new_parameters["locale_tag"],
+    ]
+    with mock.patch.object(builtins, "input", lambda _: mock_inputs()):
         Config(config_filename=tmp_v3_config)
 
     # Test config file reads correctly and contains all the new parameters


### PR DESCRIPTION
note: 
- the locale_tag is en_SG for the sake of clockify_config test
- only the locales used in this office are supported for now
- unit tests not set up yet for locale id
- the locale tag in `DEFAULT_CONF` and `clockify_config` have to both be valid but different; en_AU and en_SG have been chosen arbitrarily