### PR TITLE
cicd: add dateutil to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ REQUIREMENTS = [
     "docker~=6.0",
     "croniter~=1.3",
     "python-crontab~=2.6",
+    "python-dateutil~=2.8",
     "workalendar~=16.4.0",
 ]
 DEV_REQUIREMENTS = {


### PR DESCRIPTION
Dateutil was added as a dependency recently (last week), but for some unknown reason the build only started failing last night it was added. Other packages depend on this so it was always being installed regardless, but now we are forcing it since we use it directly.

It is possible the package that was previously depending on it, had a new release last night that no longer requires it.

Anyhow, I incorrectly assumed it was part of the standard python library, but thankfully the pipeline is alerting us to my mistake.