### PR TITLE
cicd: skip clockify tests in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,8 @@ pipeline {
                             echo "Environment: ${DOCKER_IMAGE}:${DOCKER_TAG}"
                             sh '''
                             . venv/bin/activate
-                            pytest -s
+                            # Skip clockify tests due to missing API keys.
+                            pytest -s -k 'not test_clockify'
                             '''
                         }
                     }


### PR DESCRIPTION
Skip the clockify tests since Jenkins no longer has a valid API key to test with.

These tests will need running locally from a dev with a valid API key.